### PR TITLE
Plip11838 z3c portlets: Make advanced fields/widgets (context aware) work with portlets.

### DIFF
--- a/plone/app/portlets/browser/templates/z3cform-portlets-pageform.pt
+++ b/plone/app/portlets/browser/templates/z3cform-portlets-pageform.pt
@@ -1,0 +1,28 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="plone"
+      metal:use-macro="context/main_template/macros/master">
+
+<metal:block fill-slot="top_slot"
+                 tal:define="dummy python:request.set('disable_border',1);
+                             disable_column_one python:request.set('disable_plone.leftcolumn',1);
+                             disable_column_two python:request.set('disable_plone.rightcolumn',1);" />
+
+    <metal:block fill-slot="main">
+
+        <h1 class="documentFirstHeading" tal:content="view/label | nothing" />
+
+        <div id="content-core">
+            <metal:block use-macro="context/@@ploneform-macros/titlelessform" >
+                <metal:block fill-slot="formtop">
+                     <input type="hidden" name="referer" value="" tal:attributes="value view/referer" />
+                </metal:block>
+            </metal:block>
+        </div>
+
+
+    </metal:block>
+
+</html>

--- a/plone/app/portlets/browser/z3cformhelper.py
+++ b/plone/app/portlets/browser/z3cformhelper.py
@@ -2,6 +2,7 @@ from z3c.form import button
 from z3c.form import form
 from zope.component import getMultiAdapter
 from zope.interface import implements
+from zope.app.pagetemplate.viewpagetemplatefile import ViewPageTemplateFile
 
 from Acquisition import aq_parent, aq_inner, aq_base
 from Acquisition.interfaces import IAcquirer
@@ -16,6 +17,8 @@ class AddForm(form.AddForm):
     implements(IPortletAddForm)
 
     label = _(u"Configure portlet")
+    
+    template = ViewPageTemplateFile('templates/z3cform-portlets-pageform.pt')
 
     def add(self, object):
         ob = self.context.add(object)
@@ -44,8 +47,11 @@ class AddForm(form.AddForm):
 
         return aq_base(content)
 
+    def referer(self):
+        return self.request.get('referer', '')
+
     def nextURL(self):
-        referer = self.request.get('referer')
+        referer = self.request.form.get('referer')
         if referer:
             return referer
         addview = aq_parent(aq_inner(self.context))
@@ -81,13 +87,18 @@ class EditForm(form.EditForm):
     implements(IPortletEditForm)
 
     label = _(u"Modify portlet")
+    
+    template = ViewPageTemplateFile('templates/z3cform-portlets-pageform.pt')
 
     def __call__(self):
         IPortletPermissionChecker(aq_parent(aq_inner(self.context)))()
         return super(EditForm, self).__call__()
 
+    def referer(self):
+        return self.request.get('referer', '')
+
     def nextURL(self):
-        referer = self.request.get('referer')
+        referer = self.request.form.get('referer')
         if referer:
             return referer
         editview = aq_parent(aq_inner(self.context))


### PR DESCRIPTION
Make advanced fields/widgets (context aware) work with portlets.
More advanced fields/widgets, RelationField and related widgets for instance, do not work on the addform. (Edit forms are fine).
Solution inspired by plone.dexterity is to call form.applyChanges(self, content, data).
