### PR TITLE
Prevent empty ul's in navigation tree

### DIFF
--- a/plone/app/portlets/portlets/navigation_recurse.pt
+++ b/plone/app/portlets/portlets/navigation_recurse.pt
@@ -33,10 +33,12 @@
             <span tal:content="node/Title">Selected Item Title</span>
         </a>
 
-    <ul tal:attributes="class python:'navTree navTreeLevel'+str(level)"
-        tal:condition="python: len(children) > 0 and show_children and bottomLevel and level < bottomLevel or True">
-        <span tal:replace="structure python:view.recurse(children=children, level=level+1, bottomLevel=bottomLevel)" />
-    </ul>
+        <tal:children condition="python: len(children) > 0">
+            <ul tal:attributes="class python:'navTree navTreeLevel'+str(level)"
+                tal:condition="python: len(children) > 0 and show_children and bottomLevel and level < bottomLevel or True">
+                <span tal:replace="structure python:view.recurse(children=children, level=level+1, bottomLevel=bottomLevel)" />
+            </ul>
+        </tal:children>
     </tal:level>
 </li>
 </tal:navitem>


### PR DESCRIPTION
The current navigation contains a lot of empty ul's (introduced at build 2.2.2 to fix incorrect bottomLevel handling I believe). I added an extra tal:condition around the ul. Haven't figured out how this should be done withing the current ul:condition.
