### PR TITLE
Calendar portlet use @@search

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Changelog
 2.3a2 (unreleased)
 ------------------
 
+- Calendar portlet links to @@search (plone.app.search) view instead of
+  deprecated search.pt.
+  [seanupton]
+
 - Calendar portlet search URLs whitelist only Event portal_type in the
   querystring, prevents non-event types from accidentally being
   included in calendar results. [seanupton]

--- a/plone/app/portlets/portlets/calendar.pt
+++ b/plone/app/portlets/portlets/calendar.pt
@@ -71,7 +71,7 @@
                                         tal:condition="day_event"
                                         tal:attributes="class python:is_today and 'todayevent' or 'event'"
                                        ><strong><a href=""
-                                           tal:attributes="href string:${navigation_root_url}/search?${view/getReviewStateString}start.query:record:list:date=${day/date_string}+23%3A59%3A59&amp;start.range:record=max&amp;end.query:record:list:date=${day/date_string}+00%3A00%3A00&amp;end.range:record=min&amp;Type=Event;
+                                           tal:attributes="href string:${navigation_root_url}/@@search?advanced_search=True&amp;${view/getReviewStateString}start.query:record:list:date=${day/date_string}+23%3A59%3A59&amp;start.range:record=max&amp;end.query:record:list:date=${day/date_string}+00%3A00%3A00&amp;end.range:record=min&amp;Type=Event;
                                                            title day/eventstring;"
                                            tal:content="daynumber">
                                            31


### PR DESCRIPTION
Use @@search for per-day calendar portlet links instead of deprecated ./search (search.pt).  This requires commits from https://github.com/plone/plone.app.search/pull/2 for plone.app.search to correctly support searches not containing SearchableText or Subject index queries.
