### PR TITLE
Add field to show nodes excluded from Navigation

### DIFF
--- a/plone/app/portlets/portlets/navigation.py
+++ b/plone/app/portlets/portlets/navigation.py
@@ -403,6 +403,7 @@ class NavtreeStrategy(SitemapNavtreeStrategy):
 
         topLevel = portlet.topLevel or navtree_properties.getProperty('topLevel', 0)
         self.rootPath = getRootPath(context, currentFolderOnly, topLevel, portlet.root_uid)
+        self.showExcludedFromNav = portlet.showExcludedFromNav
 
     def subtreeFilter(self, node):
         sitemapDecision = SitemapNavtreeStrategy.subtreeFilter(self, node)


### PR DESCRIPTION
Portlet navigation doesn't show nodes marked as excluded from navigation. In some use cases (admin, editor etc. specially in group portlets) would be usefull to be able to navigate also to nodes excluded from navigation. I've add a schema.field "showExcludedFromNav" that lets the user configure the portlet to show also excluded nodes. Default is False.
I did not yet changed the style of the nodes excluded from the navigation.
