### PR TITLE
feat(logging): Log more error cases with rss feeds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 3.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Log exceptions while parsing rss feeds. Get logged as info since
+  this often caused by factor out of control of site owners and
+  because the problem is handled in the UI
+  [do3cc]
 
 
 3.0.2 (2014-10-23)

--- a/plone/app/portlets/portlets/rss.py
+++ b/plone/app/portlets/portlets/rss.py
@@ -162,6 +162,8 @@ class RSSFeed(object):
                                        ACCEPTED_FEEDPARSER_EXCEPTIONS)):
                 self._loaded = True  # we tried at least but have a failed load
                 self._failed = True
+                logger.info('failed to update RSS feed %s', 
+                            d.get('bozo_exception', None))
                 return False
             try:
                 self._title = d.feed.title


### PR DESCRIPTION
Nasty, because the rest of the code ensures that after this case, no rss feed will be read for 10 minutes. At least this has a chance to show up in some logs now.