### PR TITLE
Use caching headers while getting rss, remove unconfigurable additional delay on errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,7 +111,10 @@ Changelog
   [thet]
 
 - Use plone_layout for getIcon.
-  [pbauer]
+- Log exceptions while parsing rss feeds. Get logged as info since
+  this often caused by factor out of control of site owners and
+  because the problem is handled in the UI
+  [do3cc]
 
 
 3.0.2 (2014-10-23)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,7 +83,7 @@ Changelog
 
 
 3.0.6 (2015-06-05)
------------------
+------------------
 
 - Convert manage-portlets.js into a pattern and make improvements on
   using the manage portlets infrastructure
@@ -125,6 +125,7 @@ Changelog
 
 - Use plone_layout for getIcon.
   [pbauer]
+
 
 3.0.2 (2014-10-23)
 ------------------
@@ -1351,3 +1352,4 @@ Changelog
 
 - Initial implementation.
   [optilude]
+

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,19 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- Log exceptions while parsing rss feeds. Get logged as info since
+  this often caused by factor out of control of site owners and
+  because the problem is handled in the UI
+  [do3cc]
+
+- Remove hard coded 10 minute delay if retrieving a feed failed once.
+  Either you don't need your feeds ultra fast, then you can create
+  a longer time, or you need them fast and don't want this hidden delayq
+  [do3cc]
+
+- Add caching functionality from feedparser.
+  [do3cc]
+
 - Use ``is_default_page`` instead of ``check_default_page_via_view``. 
   [fulv]
 
@@ -70,7 +83,7 @@ Changelog
 
 
 3.0.6 (2015-06-05)
-------------------
+-----------------
 
 - Convert manage-portlets.js into a pattern and make improvements on
   using the manage portlets infrastructure
@@ -111,11 +124,7 @@ Changelog
   [thet]
 
 - Use plone_layout for getIcon.
-- Log exceptions while parsing rss feeds. Get logged as info since
-  this often caused by factor out of control of site owners and
-  because the problem is handled in the UI
-  [do3cc]
-
+  [pbauer]
 
 3.0.2 (2014-10-23)
 ------------------

--- a/plone/app/portlets/portlets/rss.py
+++ b/plone/app/portlets/portlets/rss.py
@@ -162,6 +162,8 @@ class RSSFeed(object):
                                        ACCEPTED_FEEDPARSER_EXCEPTIONS)):
                 self._loaded = True  # we tried at least but have a failed load
                 self._failed = True
+                logger.info('failed to update RSS feed %s', 
+                            d.get('bozo_exception', None))
                 return False
             try:
                 self._title = d.feed.title


### PR DESCRIPTION
Unfortunately, I did not break up the two changes in two different PRs, but being quite small, I hope it is not necessary.
Change 1: Honour caching headers when getting rss requests.
Change 2: Remove the hard coded additional ten minute delay for polling rss feeds again.

Change 2 hard coded additional delays on error is a PITA if you use rss to tightly couple two internal systems and want a low delay of 1 minute only.
Otoh if you use it to get rss feeds from some random news site and don't change any polling settings, you have a default polling time of 100 minutes, on error 110 minutes, this is a bit of a joke.
Otoh if you use it to get rss feeds from some random news site and don't change any polling settings, you have a default polling time of 100 minutes, on error 110 minutes, this is a bit of a joke. So making this additional thing configurable and extend the UI to edit it, add documentation to explain what it does and so on and so on I declare this obscure feature as not needed.