### PR TITLE
 Add field to show nodes excluded from Navigation (was pull #38 and was pull #42)

### DIFF
--- a/plone/app/portlets/portlets/navigation.py
+++ b/plone/app/portlets/portlets/navigation.py
@@ -93,6 +93,16 @@ class INavigationPortlet(IPortletDataProvider):
             default=0,
             required=False)
 
+    showExcludedFromNav = schema.Bool(
+            title=_(u"label_show_excluded_from_nav",
+                    default=u"Show nodes excluded from navigation."),
+            description=_(u"help_excluded_from_nav",
+                          default=u"If selected, the navigation tree will "
+                                   "also show nodes excluded "
+                                   "from navigation."),
+            default=False,
+            required=False)
+
 
 class Assignment(base.Assignment):
     implements(INavigationPortlet)
@@ -103,14 +113,16 @@ class Assignment(base.Assignment):
     includeTop = False
     topLevel = 1
     bottomLevel = 0
+    showExcludedFromNav = False
 
-    def __init__(self, name="", root=None, currentFolderOnly=False, includeTop=False, topLevel=1, bottomLevel=0):
+    def __init__(self, name="", root=None, currentFolderOnly=False, includeTop=False, topLevel=1, bottomLevel=0, showExcludedFromNav=False):
         self.name = name
         self.root = root
         self.currentFolderOnly = currentFolderOnly
         self.includeTop = includeTop
         self.topLevel = topLevel
         self.bottomLevel = bottomLevel
+        self.showExcludedFromNav = showExcludedFromNav
 
     @property
     def title(self):
@@ -389,6 +401,16 @@ class NavtreeStrategy(SitemapNavtreeStrategy):
         else:
             return True
 
+    def nodeFilter(self, node):
+        item = node['item']
+        if getattr(item, 'getId', None) in self.excludedIds:
+            return False
+        elif self.showExcludedFromNav:
+            return True
+        elif getattr(item, 'exclude_from_nav', False):
+            return False
+        else:
+            return True
 
 def getRootPath(context, currentFolderOnly, topLevel, root):
     """Helper function to calculate the real root path

--- a/plone/app/portlets/portlets/navigation.py
+++ b/plone/app/portlets/portlets/navigation.py
@@ -297,7 +297,8 @@ class AddForm(base.AddForm):
                           currentFolderOnly=data.get('currentFolderOnly', False),
                           includeTop=data.get('includeTop', False),
                           topLevel=data.get('topLevel', 0),
-                          bottomLevel=data.get('bottomLevel', 0))
+                          bottomLevel=data.get('bottomLevel', 0),
+                          showExcludedFromNav=data.get('showExcludedFromNav', False))
 
 
 class EditForm(base.EditForm):

--- a/plone/app/portlets/portlets/navigation.py
+++ b/plone/app/portlets/portlets/navigation.py
@@ -391,6 +391,7 @@ class NavtreeStrategy(SitemapNavtreeStrategy):
 
         topLevel = portlet.topLevel or navtree_properties.getProperty('topLevel', 0)
         self.rootPath = getRootPath(context, currentFolderOnly, topLevel, portlet.root)
+        self.showExcludedFromNav = portlet.showExcludedFromNav
 
     def subtreeFilter(self, node):
         sitemapDecision = SitemapNavtreeStrategy.subtreeFilter(self, node)

--- a/plone/app/portlets/tests/test_configuration.py
+++ b/plone/app/portlets/tests/test_configuration.py
@@ -538,6 +538,7 @@ class TestGenericSetup(PortletsTestCase):
   <property name="includeTop">False</property>
   <property name="bottomLevel">0</property>
   <property name="root"></property>
+  <property name="showExcludedFromNav">False</property>
  </assignment>
  <blacklist category="user" location="/" manager="test.testcolumn"
     status="acquire"/>


### PR DESCRIPTION
Original pull-req comment:
"Portlet navigation doesn't show nodes marked as excluded from navigation. In some use cases (admin, editor etc. specially in group portlets) would be usefull to be able to navigate also to nodes excluded from navigation. I've add a schema.field "showExcludedFromNav" that lets the user configure the portlet to show also excluded nodes. Default is False.
I did not yet changed the style of the nodes excluded from the navigation." -- @me-kell

This one is again a recreation of the original pull request #38 and for #42 for the plone.app.portlets branch 2.5.x, which is Plone 4.3.x compatible (the target of this pull-request, as far as i understood).

Current state: NOT READY TO MERGE

Open tasks:
- Migration problems: Create a Plone 4.3.4 site without this branch applied, then switch to this branch and restart the Plone instance. Got to @@manage-portlets on your site's root and klick on the navigation portlet on the left side. Plone doesn't responce, nor it throws an error. However, this has to be fixed.
- Test failures: the export test in test_configuration is failing because of a missing config entry. i added it, but it's out of order and still fails. please fix that.
- Missing tests: it would be nice to have tests prooving the new functionality.

@me-kell @jensens i have to leave that unfinished for now. @me-kell can you fix the open issues?

