### PR TITLE
Plip 10359 - Security Control Panel migration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 3.0.3 (unreleased)
 ------------------
 
+- Read ``use_email_as_login`` setting from the registry instead of portal
+  properties (see https://github.com/plone/Products.CMFPlone/issues/216).
+  [jcerjak]
+
 - Use plone_layout for getIcon.
   [pbauer]
 

--- a/plone/app/portlets/portlets/login.pt
+++ b/plone/app/portlets/portlets/login.pt
@@ -30,7 +30,7 @@
             </div>
 
             <div class="field"
-                 tal:define="use_email_as_login context/portal_properties/site_properties/use_email_as_login|nothing;">
+                 tal:define="use_email_as_login python:context.portal_registry['plone.use_email_as_login'];">
 
               <tal:loginname condition="not:use_email_as_login">
                 <label for=""


### PR DESCRIPTION
Read security settings from the registry instead of portal properties. This is part of work on the security control panel migration: https://github.com/plone/Products.CMFPlone/issues/216

This should be merged along with https://github.com/plone/Products.CMFPlone/pull/362
