### PR TITLE
Make exporting field definitions in assignments recursive, to handle complex data structures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Change the logic for retrieving and storing values of portlets in the assignment exportimport handler to allow for non-trivial data structures.
+  [MatthewWilkes]
 
 
 2.5.2 (2014-09-07)


### PR DESCRIPTION
Portlet assignments can contain arbitrary data, but the exporter only covers the simple cases used by core. This change allows for Object and List fields to be exported properly, regardless of what they contain.