### PR TITLE
Global defines will be removed in 5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.0.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove usage of global defines in classic portlet. 
+  [esteele]
 
 
 3.0.7 (2015-07-18)

--- a/plone/app/portlets/portlets/classic.pt
+++ b/plone/app/portlets/portlets/classic.pt
@@ -1,4 +1,3 @@
-<metal:block use-macro="here/global_defines/macros/defines" />
 <tal:block tal:define="use_macro view/use_macro;
                        path_expression view/path_expression">
 


### PR DESCRIPTION
Need a sanity check on this one. Anything that previously referenced a global defines variable could be added the template referenced an instance of the classic portlet, so that we don't need to inject all of our globals in the base portlet template, right?

See also https://github.com/plone/Products.CMFPlone/issues/836