### PR TITLE
If 'currentFolderOnly', navigation portlet header link should go to current folder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 3.0.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- If 'currentFolderOnly', navigation portlet header link should go to current
+  folder, not to sitemap
+  [ebrehault]
 
 
 3.0.9 (2015-09-09)

--- a/plone/app/portlets/portlets/navigation.py
+++ b/plone/app/portlets/portlets/navigation.py
@@ -185,7 +185,7 @@ class Renderer(base.Renderer):
         displaying /sitemap links for anything besides nav root.
         """
 
-        if not self.data.root_uid:
+        if not self.data.root_uid and not self.data.currentFolderOnly:
             # No particular root item assigned -> should get link to the
             # navigation root sitemap of the current context acquisition chain
             portal_state = getMultiAdapter((self.context, self.request), name="plone_portal_state")


### PR DESCRIPTION
...not to sitemap