### PR TITLE
fix: links in RSS portlets when using special characters.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Fix links in RSS portlets when using special characters.
+  [Gagaro]
 
 
 3.1.2 (2015-09-27)

--- a/plone/app/portlets/portlets/rss.pt
+++ b/plone/app/portlets/portlets/rss.pt
@@ -25,7 +25,7 @@
               tal:attributes="class python:oddrow and 'portletItem even' or 'portletItem odd'">
 
               <a href="#"
-                  tal:attributes="href string:${item/url}"
+                  tal:attributes="href item/url"
                   class="tile">
                   <span tal:replace="item/title">
                       Title


### PR DESCRIPTION
URL with special characters such as `&` will be HTML escaped (as `&amp;` for `&`) and cause the link to break.

removing `string:` from the tal expression resolves this.