### PR TITLE
Fix #65: add jumplist between portlet managers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Incompatibilities:
 
 New:
 
-- *add item here*
+- Add jumplist to provide quick access across portlet managers
+  [davilima6]
 
 Fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-4.0.1 (unreleased)
+4.1.0 (unreleased)
 ------------------
 
 Incompatibilities:

--- a/plone/app/portlets/browser/templates/topbar-manage-portlets.pt
+++ b/plone/app/portlets/browser/templates/topbar-manage-portlets.pt
@@ -7,11 +7,38 @@
 <body>
 
   <div metal:fill-slot="main" tal:define="plone_view context/@@plone">
+
+    <div class="quicknav-wrapper pat-manage-portlets">
+      <form method="post"
+          tal:attributes="action context/absolute_url">
+        <select id="quicknav" class="add-portlet pull-right" name=":action"
+            style="width: auto; margin-top: 0.5em;"
+            tal:define="portlet_menu context/@@view_get_menu/plone_contentmenu_portletmanager"
+            tal:attributes="data-context-url context/absolute_url">
+          <tal:item repeat="item portlet_menu">
+            <option tal:define="item_id python:item['title'].lower().replace(' ', '.');
+                                is_current python:item_id == view.manager_name"
+                tal:attributes="value item/action"
+                tal:content="item/title"
+                tal:omit-tag="is_current">Plone Leftcolumn</option>
+          </tal:item>
+        </select>
+        <label for="quicknav" i18n:translate="title_manage_contextual_portlets" class="pull-right" style="margin-right: 0.5em; padding-top: 1em;">Quick access: </label>
+      </form>
+    </div>
+
     <h1 class="documentFirstHeading"
       i18n:translate="title_manage_contextual_portlets">
       Manage portlets for
       <q i18n:name="context_title" tal:content="context/Title">title</q>
     </h1>
+
+    <a class="link-parent"
+        tal:attributes="href context/absolute_url"
+        i18n:translate="return_to_view">
+      Return
+    </a>
+
     <div class="portalMessage info"
         tal:condition="plone_view/isDefaultPageInFolder|nothing">
       <strong>

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '4.0.1.dev0'
+version = '4.1.0.dev0'
 
 setup(
     name='plone.app.portlets',


### PR DESCRIPTION
1) IMO for making optimal use of the jumplist, content should be loaded via Ajax. In this PR I added no JS and instead took advantage of existing [`setupAddDropdown` code](https://github.com/plone/plone.app.portlets/blob/master/plone/app/portlets/browser/manage-portlets.js#L151-L163) so managers open in a modal.

1.1) I did some tests and could add/edit/remove portlets inside the modals. I only noticed one inconsistency: editing a portlet closes the modal and redirects browser so after edition is saved or cancelled Plone doesn't return to the original accessed manager (i.e. `@@topbar-manage-portlets/plone.originalcolumn`). It's not that bad but If you think it's best I can add JS to update only current `#content` and thus discard the modals (in this case we should drop the related code from `manage-portlets.js` as well)

2) Another issue is whether we prefer to set `<select>`'s initial state to a label (e.g. "Other portlet managers") instead of a real option.

3) I also added missing "Return" button in this PR. Should I add a separate CHANGES entry for that?

4) Finally, some css styles are inline. If everything else is accepted I'm glad to move them to https://github.com/plone/plonetheme.barceloneta/blob/master/plonetheme/barceloneta/theme/less/portlets.plone.less#L167 where they seem more appropriate.