### PR TITLE
Fixed links in RSS portlets when they have special characters.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.5.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed links in RSS portlets when they have special characters and we use chameleon.  [maurits]
 
 
 2.5.4 (2015-08-14)

--- a/plone/app/portlets/portlets/rss.pt
+++ b/plone/app/portlets/portlets/rss.pt
@@ -25,7 +25,7 @@
             tal:attributes="class python:oddrow and 'portletItem even' or 'portletItem odd'">
 
             <a href="#"
-                tal:attributes="href string:${item/url}"
+                tal:attributes="href item/url"
                 class="tile">
                 <span tal:replace="item/title">
                     Title


### PR DESCRIPTION
This happens when we use chameleon.
Backport from a fix by Gagaro:
https://github.com/plone/plone.app.portlets/commit/2f99af207d655d27ede4e4573324685718708765