### PR TITLE
Change plone-manage-portlets to use Patternslib base pattern pat-base.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Bug fixes:
 
 - Use zope.interface decorator.
   [gforcada]
+- Change ``plone-manage-portlets`` to use Patternslib base pattern ``pat-base``.
+  [thet]
 
 
 4.1.2 (2016-06-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Bug fixes:
 
 - Use zope.interface decorator.
   [gforcada]
+
 - Change ``plone-manage-portlets`` to use Patternslib base pattern ``pat-base``.
   [thet]
 

--- a/plone/app/portlets/browser/manage-portlets.js
+++ b/plone/app/portlets/browser/manage-portlets.js
@@ -1,13 +1,12 @@
 define([
   'jquery',
-  'mockup-patterns-base',
-  'pat-registry',
+  'pat-base',
   'mockup-utils',
   'mockup-patterns-modal',
   'translate',
   'pat-logger',
   'jquery.form'
-], function ($, Base, Registry, utils, Modal, _t, logger) {
+], function ($, Base, utils, Modal, _t, logger) {
   'use strict';
 
   var log = logger.getLogger('pat-manage-portlets');
@@ -15,6 +14,7 @@ define([
   var ManagePortlets = Base.extend({
     name: 'manage-portlets',
     trigger: '.pat-manage-portlets',
+    parser: 'mockup',
     messageTimeout: 0,
     submitTimeout: 0,
     switchTimeout: 0,


### PR DESCRIPTION
Fixes some console warnings but not the strange ``define is not a function`` errors I encounter currently :\

Different story: this pattern should better moved to mockup. Ref: https://github.com/plone/Products.CMFPlone/issues/1653