### PR TITLE
Use absolute source URL in navigation portlet's thumbnails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+
 4.1.3 (unreleased)
 ------------------
 
@@ -16,6 +17,7 @@ New features:
 - Upgrade news portlet to use the new select widget;
   Add dependency on plone.app.z3cform
   [datakurre]
+
 - Tracebak info on importing ``portlets.xml`` to show better error location in the xml
   [SyZn]
 
@@ -26,6 +28,9 @@ Bug fixes:
 
 - Change ``plone-manage-portlets`` to use Patternslib base pattern ``pat-base``.
   [thet]
+
+- Use absolute source URL in navigation portlet's thumbnails
+  [davilima6]
 
 
 4.1.2 (2016-06-07)
@@ -38,6 +43,7 @@ Bug fixes:
 
 - Remove Plone 3 compatibility code
   [tomgross]
+
 
 4.1.1 (2016-05-26)
 ------------------
@@ -191,12 +197,14 @@ Fixes:
 - Remove CMFDefault dependency
   [tomgross]
 
+
 3.0.5 (2015-05-12)
 ------------------
 
 - Supress a ZopeTestCase warning.
   This fixes https://github.com/plone/Products.CMFPlone/issues/501
   [gforcada]
+
 
 3.0.4 (2015-05-04)
 ------------------
@@ -301,6 +309,7 @@ Fixes:
 - Fix navigation root of portlets when root field is unicode.
   This is the case when portlet is imported with generic setup.
   [thomasdesvenain]
+
 
 2.5a1 (2013-10-05)
 ------------------
@@ -436,11 +445,13 @@ Fixes:
   displayed with CSS or an img tag.
   [danjacka]
 
+
 2.3.5 (2012-09-28)
 ------------------
 
 - Fix inheritance hierarchy of IPortletForm to reflect usage in z3cformhelper.
   [elro]
+
 
 2.3.4 (2012-09-28)
 ------------------
@@ -448,12 +459,14 @@ Fixes:
 - Tweak z3c.form add/edit forms to disable edit bar and columns.
   [elro]
 
+
 2.3.3 (2012-09-27)
 ------------------
 
 - Portlets are now registered for IDefaultPortletManager by default to allow
   for easier creation of custom portlet managers with restricted portlets.
   [elro]
+
 
 2.3.2 (2012-09-26)
 ------------------
@@ -487,11 +500,13 @@ Fixes:
 
 - Add safety check for portletHeader links [davilima6]
 
+
 2.3.1 (2012-08-29)
 ------------------
 
 - Fix packaging error.
   [esteele]
+
 
 2.3 (2012-08-29)
 ----------------
@@ -535,11 +550,13 @@ Fixes:
   manage-portlets viewlet
   [toutpt]
 
+
 2.3a1 (2012-06-29)
 ------------------
 
 - Make it possible to create portlets using z3c.form.
   [ggozad]
+
 
 2.2.6 (unreleased)
 ------------------
@@ -550,6 +567,7 @@ Fixes:
 - accessibility improvements for screen readers regarding "more" links, see
   https://dev.plone.org/ticket/11982
   [rmattb, applied by polyester]
+
 
 2.2.5 (2012-05-07)
 ------------------
@@ -568,6 +586,7 @@ Fixes:
 - Fix inherited local portlets for objects allowing locally-assigned
   portlets which are contained by an object that does not.
   [mitchellrj]
+
 
 2.2.3 (2011-11-24)
 ------------------
@@ -612,12 +631,14 @@ Fixes:
   JS handling of the same functionality.
   [spliter]
 
+
 2.2 - 2011-07-19
 ----------------
 
 - Updated 'Advanced Search' link and form's action of the search portlet to
   link to updated search results view at @@search.
   [spliter]
+
 
 2.1.5 - 2011-06-19
 ------------------

--- a/plone/app/portlets/portlets/navigation_recurse.pt
+++ b/plone/app/portlets/portlets/navigation_recurse.pt
@@ -1,6 +1,6 @@
-<tal:master define="level options/level|python:0;
+<tal:master define="level options/level | python:0;
                     children options/children | nothing;
-                    bottomLevel options/bottomLevel | nothing;"
+                    bottomLevel options/bottomLevel | nothing"
             i18n:domain="plone">
 
 <metal:main define-macro="nav_main">
@@ -15,31 +15,32 @@
                 imageBase       node/path;
                 is_current      node/currentItem;
                 is_in_path      node/currentParent;
-                li_class        python:is_current and ' navTreeCurrentNode' or '';
-                li_extr_class   python:is_in_path and ' navTreeItemInPath' or '';
-                li_folder_class python:show_children and ' navTreeFolderish' or '';
-                normalizeString nocall: context/plone_utils/normalizeString;"
-    tal:attributes="class string:navTreeItem visualNoMarker${li_class}${li_extr_class}${li_folder_class} section-${node/normalized_id}"
-    tal:condition="python:bottomLevel &lt;= 0 or level &lt;= bottomLevel">
+                li_class        python:' navTreeCurrentNode' if is_current else '';
+                li_extr_class   python:' navTreeItemInPath' if is_in_path else '';
+                li_folder_class python:' navTreeFolderish' if show_children else '';
+                normalizeString nocall: context/plone_utils/normalizeString"
+    tal:condition="python:bottomLevel &lt;= 0 or level &lt;= bottomLevel"
+    tal:attributes="class string:navTreeItem visualNoMarker${li_class}${li_extr_class}${li_folder_class} section-${node/normalized_id}">
 
     <tal:level define="item_class string:state-${node/normalized_review_state};
-                       item_type_class python:'contenttype-' + normalizeString(item_type);
-                       item_class python:is_current and item_class + ' navTreeCurrentItem' or item_class;">
+                       item_type_class python:'contenttype-%s' % normalizeString(item_type);
+                       item_class python:'%s navTreeCurrentItem' % item_class if is_current else item_class">
 
-        <a tal:attributes="href python:use_remote_url and item_remote_url or item_url;
+        <a tal:attributes="href  python:item_remote_url if use_remote_url else item_url;
                            title node/Description;
-                           class string:$item_class${li_class}${li_extr_class}${li_folder_class} $item_type_class">          
-              <img class="image-icon"
-                 tal:define="getIcon string:$imageBase/@@images/image/icon"
-                 tal:condition="hasImage"                    
-                 tal:attributes="href string:item_url;
-                                 src  string:$getIcon">                        
-              <span tal:replace="node/Title">Selected Item Title</span>
+                           class string:${item_class}${li_class}${li_extr_class}${li_folder_class} ${item_type_class}">
+            <img class="image-icon"
+                tal:define="portal_url context/@@plone_portal_state/portal_url;
+                            icon_url string:${portal_url}/${imageBase}/@@images/image/icon"
+                tal:condition="hasImage"
+                tal:attributes="src icon_url;
+                                alt node/Description">
+            <span tal:replace="node/Title">Selected Item Title</span>
         </a>
 
-        <tal:children condition="python: len(children) > 0">
-            <ul tal:attributes="class python:'navTree navTreeLevel'+str(level)"
-                tal:condition="python: len(children) > 0 and show_children and bottomLevel and level < bottomLevel or True">
+        <tal:children condition="children">
+            <ul tal:attributes="class python:'navTree navTreeLevel%s' % level"
+                tal:condition="python: children and show_children and bottomLevel and level < bottomLevel">
                 <span tal:replace="structure python:view.recurse(children=children, level=level+1, bottomLevel=bottomLevel)" />
             </ul>
         </tal:children>


### PR DESCRIPTION
Problem can be seen in Plone 5.0.5 final, see: https://www.plone-demo.info/news/newsitem-9