### PR TITLE
Apply security hotfix 20160830 for redirects. [2.5.x, Plone 4.3]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Apply security hotfix 20160830 for redirects.  Also, made sure that
+  all form views have a ``referer`` property: until now some did not
+  have it, some had it as property, some had it as method.  [maurits]
 
 
 2.5.5 (2016-06-12)

--- a/plone/app/portlets/browser/adding.py
+++ b/plone/app/portlets/browser/adding.py
@@ -7,6 +7,7 @@ from zope.container.interfaces import INameChooser
 
 from Acquisition import aq_inner, aq_base, aq_parent
 from OFS.SimpleItem import SimpleItem
+from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
 
 from plone.app.portlets.browser.interfaces import IPortletAdding
@@ -34,9 +35,14 @@ class PortletAdding(SimpleItem, BrowserView):
         chooser = INameChooser(manager)
         manager[chooser.chooseName(None, content)] = content
 
+    @property
+    def referer(self):
+        return self.request.get('referer', '')
+
     def nextURL(self):
-        referer = self.request.get('referer')
-        if not referer:
+        urltool = getToolByName(self.context, 'portal_url')
+        referer = self.referer
+        if not referer or not urltool.isURLInPortal(referer):
             context = aq_parent(aq_inner(self.context))
             url = str(getMultiAdapter((context, self.request), name=u"absolute_url"))
             referer = url + '/@@manage-portlets'

--- a/plone/app/portlets/browser/editmanager.py
+++ b/plone/app/portlets/browser/editmanager.py
@@ -26,6 +26,7 @@ from AccessControl import Unauthorized
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.PythonScripts.standard import url_quote, url_unquote
+from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 
 from plone.app.portlets.browser.interfaces import IManageColumnPortletsView
@@ -429,9 +430,11 @@ class ManagePortletAssignments(BrowserView):
 
     def _nextUrl(self):
         referer = self.request.get('referer')
+        urltool = getToolByName(self.context, 'portal_url')
         if referer:
             referer = url_unquote(referer)
-        else:
+
+        if not referer or not urltool.isURLInPortal(referer):
             context = aq_parent(aq_inner(self.context))
             url = str(getMultiAdapter((context, self.request), name=u"absolute_url"))
             referer = '%s/@@manage-portlets' % (url,)

--- a/plone/app/portlets/tests/test_redirects.py
+++ b/plone/app/portlets/tests/test_redirects.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from plone.app.portlets.browser.adding import PortletAdding
+from plone.app.portlets.browser.editmanager import ManagePortletAssignments
+from plone.app.portlets.browser.formhelper import AddForm
+from plone.app.portlets.browser.formhelper import EditForm
+from plone.app.portlets.browser import z3cformhelper
+from plone.app.portlets.tests.base import PortletsTestCase
+
+
+class TestRedirects(PortletsTestCase):
+    _test_methods = [
+        (PortletAdding, 'nextURL'),
+        (ManagePortletAssignments, '_nextUrl'),
+        (AddForm, 'nextURL'),
+        (EditForm, 'nextURL'),
+        (z3cformhelper.AddForm, 'nextURL'),
+        (z3cformhelper.EditForm, 'nextURL'),
+    ]
+
+    def test_regression(self):
+        portal_url = self.portal.absolute_url()
+        request = self.portal.REQUEST
+        request.form.update({
+            'referer': portal_url
+        })
+        for Klass, method in self._test_methods:
+            view = Klass(self.portal, request)
+            view.__parent__ = self.portal
+            self.assertEqual(getattr(view, method)(), portal_url)
+
+    def test_valid_next_url(self):
+        request = self.portal.REQUEST
+        request.form.update({
+            'referer': 'http://attacker.com'
+        })
+        for Klass, method in self._test_methods:
+            view = Klass(self.portal, request)
+            view.__parent__ = self.portal
+            self.assertNotEqual('http://attacker.com', getattr(view, method)())
+
+
+def test_suite():
+    # Without this test_suite, there is a strange error when running the tests:
+    #
+    # Error in test runTest
+    # (plone.app.portlets.tests.base.PortletsTestCase)
+    # Traceback (most recent call last):
+    #   File "unittest2-0.5.1-py2.7.egg/unittest2/case.py", line 340, in run
+    #     testMethod()
+    #   TypeError: 'NoneType' object is not callable
+    #
+    # You get the error when running
+    # bin/test -s plone.app.portlets
+    # or
+    # bin/test -s plone.app.portlets -t run
+    # but not with
+    # bin/test -s plone.app.portlets -m test_redirects
+    # But the error *is* in this test_redirects.py file,
+    # because it goes away when I delete this file.
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestRedirects))
+    return suite


### PR DESCRIPTION
Also, made sure that all form views have a `referer` property: until now some did not have it, some had it as property, some had it as method.