### PR TITLE
OFS.traversable cannot do unicode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Make sure, that ``utils.assignment_mapping_from_key`` traverses only to non-unicode paths.
+  OFS.traversable doesn't accept unicode paths.
+  [thet]
 
 
 4.2.2 (2016-11-18)

--- a/plone/app/portlets/tests/test_utils.py
+++ b/plone/app/portlets/tests/test_utils.py
@@ -31,6 +31,17 @@ class TestAssignmentFromKey(PortletsTestCase):
         a = assignment_from_key(self.portal, u'plone.leftcolumn', CONTEXT_CATEGORY, path, 'foo')
         self.assertEqual(c, a)
 
+    def testGetPortletFromContextUnicodePath(self):
+        """Do not fail, if path is a unicode object.
+        plone.portlets.utils.unhashPortletInfo returns a unicode path key.
+        """
+        mapping = getMultiAdapter((self.portal, self.manager), IPortletAssignmentMapping)
+        c = classic.Assignment()
+        mapping['foo'] = c
+        path = u'/'.join(self.portal.getPhysicalPath())
+        a = assignment_from_key(self.portal, u'plone.leftcolumn', CONTEXT_CATEGORY, path, 'foo')
+        self.assertEqual(c, a)
+
     def testGetPortletFromUserCategory(self):
         c = classic.Assignment()
         self.cat[user_name]['foo'] = c

--- a/plone/app/portlets/utils.py
+++ b/plone/app/portlets/utils.py
@@ -50,6 +50,7 @@ def assignment_mapping_from_key(context, manager_name, category, key, create=Fal
                 path = path[len(portal_path)+1:]
             while path.startswith('/'):
                 path = path[1:]
+            path = path.encode('utf-8')  # OFS.traversable cannot do unicode
             obj = portal.restrictedTraverse(path, None)
         if obj is None:
             raise KeyError, "Cannot find object at path %s" % path


### PR DESCRIPTION
Make sure, that ``utils.assignment_mapping_from_key`` traverses only to non-unicode paths.
OFS.traversable doesn't accept unicode paths.

/cc @davisagli - that issue came up with: https://github.com/plone/plone.portlets/commit/ec30810b6be108d4deb69585ab1b35c87d8e6838
doing ``u'/path'.encode('utf-8')`` should be Py3 forward compatible.

This problems occurs when trying to call ``@@render-portlet`` with a portlet hash.