### PR TITLE
WIP: Portlet add and edit forms AutoExtensibleForm. But some portlet addfo…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,13 @@ Bug fixes:
   so attributes of the renderer will no longer be wrapped.
   [davisagli]
 
+- Portlet add and edit forms AutoExtensibleForm. But some portlet
+  addforms fail on creating the Assignment, if there is a FormExtender
+  for the form, and the addform uses "Assignment(**data)" for creation
+  and not "Assignment(key=data.get(key, None))". Fix this by filtering
+  away data values that does not come from the 'core' schema.
+  [sunew]
+
 
 4.3.1 (2017-08-07)
 ------------------

--- a/plone/app/portlets/browser/formhelper.py
+++ b/plone/app/portlets/browser/formhelper.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from z3c.form import button
+from z3c.form import field
 from z3c.form import form
 from zope.component import getMultiAdapter
 from zope.interface import implementer
@@ -60,7 +61,14 @@ class AddForm(AutoExtensibleForm, form.AddForm):
         return super(AddForm, self).__call__()
 
     def createAndAdd(self, data):
-        obj = self.create(data)
+        # Filter away data values that does not come from the 'core' schema.
+        # Additional values can come from AutoExtensibleForm/FormExtender schemas,
+        # and the portlet Assignment creation will fail if using "Assignment(**data)".
+        # Extender values are set in form.applyChanges  below.
+        schema_keys = field.Fields(self.schema).keys()
+        unextended_data = { key: data[key] for key in schema_keys }
+
+        obj = self.create(unextended_data)
 
         # Acquisition wrap temporarily to satisfy things like vocabularies
         # depending on tools

--- a/plone/app/portlets/browser/formhelper.py
+++ b/plone/app/portlets/browser/formhelper.py
@@ -66,7 +66,7 @@ class AddForm(AutoExtensibleForm, form.AddForm):
         # and the portlet Assignment creation will fail if using "Assignment(**data)".
         # Extender values are set in form.applyChanges  below.
         schema_keys = field.Fields(self.schema).keys()
-        unextended_data = { key: data[key] for key in schema_keys }
+        unextended_data = { key: data[key] for key in schema_keys if data.has_key(key)}
 
         obj = self.create(unextended_data)
 


### PR DESCRIPTION
…rms fail on creating the Assignment, if there is a FormExtender for the form,

and the addform uses "Assignment(**data)" for creation and not "Assignment(key=data.get(key, None))".
Fix this by filtering away data values that does not come from the 'core' schema.