### PR TITLE
Adapt tests to `Products.GenericSetup >= 2.0`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,9 @@ Changelog
 
 Breaking changes:
 
-- *add item here*
+- Adapt tests to `Products.GenericSetup >= 2.0` thus requiring at least that
+  version.
+  [icemac]
 
 New features:
 

--- a/plone/app/portlets/tests/test_configuration.py
+++ b/plone/app/portlets/tests/test_configuration.py
@@ -431,7 +431,7 @@ class TestGenericSetup(PortletsTestCase):
         portal_setup.runAllImportStepsFromProfile('profile-plone.app.portlets:testing')
 
         expected = """\
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <portlets>
  <portletmanager name="test.testcolumn"
     type="plone.app.portlets.tests.test_configuration.ITestColumn"/>

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'Products.CMFPlone',
         'Products.CMFCore',
         'Products.CMFDynamicViewFTI',
-        'Products.GenericSetup',
+        'Products.GenericSetup >= 2.0.dev0',
         'Products.PluggableAuthService',
         'ZODB3',
         'Acquisition',


### PR DESCRIPTION
This is needed to get Plone 5.2 coredev buildout green again. After the Python 3 changes of `Products.GenericSetup` have been merged to master.