### PR TITLE
[a11y] Added role attribute for portalMessage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- a11y: Added role attribute for portalMessage
+  [nzambello]
 
 
 4.4.0 (2018-10-31)

--- a/plone/app/portlets/browser/templates/manage-contextual.pt
+++ b/plone/app/portlets/browser/templates/manage-contextual.pt
@@ -33,7 +33,8 @@
     </tal:block>
 
       <div class="portalMessage info"
-          tal:condition="plone_view/isDefaultPageInFolder|nothing">
+           role="status"
+           tal:condition="plone_view/isDefaultPageInFolder|nothing">
         <strong i18n:translate="">
             Info
         </strong>

--- a/plone/app/portlets/browser/templates/topbar-manage-portlets.pt
+++ b/plone/app/portlets/browser/templates/topbar-manage-portlets.pt
@@ -41,7 +41,8 @@
     </a>
 
     <div class="portalMessage info"
-        tal:condition="plone_view/isDefaultPageInFolder|nothing">
+         role="status"
+         tal:condition="plone_view/isDefaultPageInFolder|nothing">
       <strong>
           Info
       </strong>


### PR DESCRIPTION
Screen readers could now see and read correctly alerts/status messages.