### PR TITLE
Fix portlet types from removed code breaking @@manage-portlets:

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix portlet types from removed code breaking @@manage-portlets.
+  [rpatterson]
 
 
 3.1.5 (2016-09-23)

--- a/plone/app/portlets/browser/editmanager.py
+++ b/plone/app/portlets/browser/editmanager.py
@@ -159,9 +159,8 @@ class EditPortletManagerRenderer(Explicit):
             addview = "%s/+/%s" % (addviewbase, addview,)
             if addview.startswith('/'):
                 addview = addview[1:]
-            try:
-                self.context.restrictedTraverse(str(addview))
-            except (AttributeError, KeyError, Unauthorized,):
+            if self.context.restrictedTraverse(
+                    str(addview), default=None) is None:
                 return False
             return True
 


### PR DESCRIPTION
```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module Products.PDBDebugMode.runcall, line 70, in pdb_runcall
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.Five.browser.metaconfigure, line 485, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 261, in render
  Module chameleon.template, line 171, in render
  Module 4e3cb452b99b6db6631312f79196a6fb.py, line 337, in render
  Module 37a03bbe386e0ba4b20e0aaa8843f61f.py, line 1223, in render_master
  Module 37a03bbe386e0ba4b20e0aaa8843f61f.py, line 458, in render_content
  Module 4e3cb452b99b6db6631312f79196a6fb.py, line 299, in __fill_main
  Module five.pt.expressions, line 161, in __call__
  Module plone.app.portlets.browser.manage, line 417, in render_edit_manager_portlets
  Module plone.app.portlets.browser.editmanager, line 72, in render
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 261, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 885b441d3286efa475b323eefd82b95a.py, line 156, in render
  Module 4ba2180e0dc0e468bc73b0cbdf884c30.py, line 143, in render_portlet_add_form
  Module five.pt.expressions, line 161, in __call__
  Module plone.app.portlets.browser.editmanager, line 172, in addable_portlets
  Module plone.app.portlets.browser.editmanager, line 163, in check_permission
  Module OFS.Traversable, line 317, in restrictedTraverse
  Module OFS.Traversable, line 300, in unrestrictedTraverse
   - __traceback_info__: ([], 'collective.quickupload.QuickUploadPortlet')
NotFound: collective.quickupload.QuickUploadPortlet

 - Expression: "view/render_edit_manager_portlets"
 - Filename:   ... app/portlets/browser/templates/topbar-manage-portlets.pt
 - Location:   (line 32: col 33)
 - Source:     ... place="structure view/render_edit_manager_portlets" />
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Expression: "view/addable_portlets"
 - Filename:   ... ne/app/portlets/browser/templates/edit-manager-macros.pt
 - Location:   (line 4: col 31)
 - Source:     tal:define="portlets view/addable_portlets"
                                    ^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x7f82bd451ed0>
               views: <ViewMapper - at 0x7f82bce3b510>
               modules: <instance - at 0x7f82c8167488>
               args: <tuple - at 0x7f82cd138050>
               here: <ImplicitAcquisitionWrapper home at 0x7f82be6ca1e0>
               user: <ImplicitAcquisitionWrapper - at 0x7f82bfd11f50>
               nothing: <NoneType - at 0x5571ad9dc560>
               container: <ImplicitAcquisitionWrapper home at 0x7f82be6ca1e0>
               request: <instance - at 0x7f82bd20d9e0>
               wrapped_repeat: <SafeMapping - at 0x7f82bfc7a100>
               traverse_subpath: <list - at 0x7f82bd20def0>
               default: <object - at 0x7f82cd050550>
               loop: {...} (0)
               context: <ImplicitAcquisitionWrapper home at 0x7f82be6ca1e0>
               view: <ContextualEditPortletManagerRenderer - at 0x7f82bce3bc10>
               translate: <function translate at 0x7f82be25c668>
               root: <ImplicitAcquisitionWrapper Zope at 0x7f82bff26410>
               options: {...} (0)
               target_language: <NoneType - at 0x5571ad9dc560>
```