### PR TITLE
Fixes for exception raised in navigation portlet by File with unknown content-type in mime registry

### DIFF
--- a/news/cmfplone-2882.bugfix
+++ b/news/cmfplone-2882.bugfix
@@ -1,0 +1,4 @@
+fixes  index error in navigation portlet caused by unknown mimetypes without
+entry in mimetype registry
+https://github.com/plone/Products.CMFPlone/issues/2882)
+

--- a/plone/app/portlets/portlets/navigation.py
+++ b/plone/app/portlets/portlets/navigation.py
@@ -356,6 +356,8 @@ class Renderer(base.Renderer):
             mtt = getToolByName(self.context, 'mimetypes_registry')
             if fileo.contentType:
                 ctype = mtt.lookup(fileo.contentType)
+                if not ctype:
+                    return None
                 return os.path.join(
                     portal_url,
                     guess_icon_path(ctype[0])


### PR DESCRIPTION
https://github.com/plone/plone.app.portlets/pull/new/issuse-cmfplone-2882