### PR TITLE
Links in portlet calendar were broken

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Bug fixes:
 
 - Links in the portlet calendar were with ``&amp;`` which were not always interpreted by recent browsers.
   Replaced them by standards '&'. [jihaisse]
+- Same for ``%3A`` replaced by ':'
 
 
 2.5.6 (2016-10-03)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Bug fixes:
 
 - Links in the portlet calendar were with ``&amp;`` which were not always interpreted by recent browsers.
   Replaced them by standards '&'. [jihaisse]
-- Same for ``%3A`` replaced by ':'
+- Same for ``%3A`` replaced by ':' [jihaisse]
 
 
 2.5.6 (2016-10-03)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Links in the portlet calendar were with ``&amp;`` which were not always interpreted by recent browsers.
+  Replaced them by standards '&'. [jihaisse]
 
 
 2.5.6 (2016-10-03)

--- a/plone/app/portlets/portlets/calendar.pt
+++ b/plone/app/portlets/portlets/calendar.pt
@@ -19,7 +19,7 @@
            tal:define="prevMonthMonth view/prevMonthMonth;
                        prevMonthYear view/prevMonthYear"
            tal:attributes="id python:showPrevMonth and 'calendar-previous' or '';
-                           href python:'?%smonth:int=%d&amp;year:int=%d&amp;orig_query=%s' % (query_string, prevMonthMonth, prevMonthYear, url_quote_plus(query_string));
+                           href python:'?%smonth:int=%d&year:int=%d&orig_query=%s' % (query_string, prevMonthMonth, prevMonthYear, url_quote_plus(query_string));
                            data-year prevMonthYear;
                            data-month prevMonthMonth;"
            tal:condition="showPrevMonth"
@@ -40,7 +40,7 @@
            tal:define="nextMonthMonth view/nextMonthMonth;
                        nextMonthYear view/nextMonthYear"
            tal:attributes="id python:showNextMonth and 'calendar-next' or '';
-                           href python:'?%smonth:int=%d&amp;year:int=%d&amp;orig_query=%s' % (query_string, nextMonthMonth, nextMonthYear, url_quote_plus(query_string));
+                           href python:'?%smonth:int=%d&year:int=%d&orig_query=%s' % (query_string, nextMonthMonth, nextMonthYear, url_quote_plus(query_string));
                            data-year nextMonthYear;
                            data-month nextMonthMonth;"
            tal:condition="showNextMonth"
@@ -75,7 +75,7 @@
                                         tal:condition="day_event"
                                         tal:attributes="class python:is_today and 'todayevent' or 'event'"
                                        ><strong><a href=""
-                                           tal:attributes="href string:${navigation_root_url}/@@search?advanced_search=True&amp;${view/getReviewStateString}start.query:record:list:date=${day/date_string}+23%3A59%3A59&amp;start.range:record=max&amp;end.query:record:list:date=${day/date_string}+00%3A00%3A00&amp;end.range:record=min&amp;list:&amp;${view/getEventTypes};
+                                           tal:attributes="href string:${navigation_root_url}/@@search?advanced_search=True&${view/getReviewStateString}start.query:record:list:date=${day/date_string}+23%3A59%3A59&start.range:record=max&end.query:record:list:date=${day/date_string}+00%3A00%3A00&end.range:record=min&list:&${view/getEventTypes};
                                                            title day/eventstring;"
                                            tal:content="daynumber">
                                            31

--- a/plone/app/portlets/portlets/calendar.pt
+++ b/plone/app/portlets/portlets/calendar.pt
@@ -75,7 +75,7 @@
                                         tal:condition="day_event"
                                         tal:attributes="class python:is_today and 'todayevent' or 'event'"
                                        ><strong><a href=""
-                                           tal:attributes="href string:${navigation_root_url}/@@search?advanced_search=True&${view/getReviewStateString}start.query:record:list:date=${day/date_string}+23%3A59%3A59&start.range:record=max&end.query:record:list:date=${day/date_string}+00%3A00%3A00&end.range:record=min&list:&${view/getEventTypes};
+                                           tal:attributes="href string:${navigation_root_url}/@@search?advanced_search=True&${view/getReviewStateString}start.query:record:list:date=${day/date_string}+23:59:59&start.range:record=max&end.query:record:list:date=${day/date_string}+00:00:00&end.range:record=min&list:&${view/getEventTypes};
                                                            title day/eventstring;"
                                            tal:content="daynumber">
                                            31

--- a/plone/app/portlets/portlets/calendar.py
+++ b/plone/app/portlets/portlets/calendar.py
@@ -230,10 +230,10 @@ class Renderer(base.Renderer):
 
     def getReviewStateString(self):
         states = self.calendar.getCalendarStates()
-        return ''.join(map(lambda x: 'review_state=%s&amp;' % self.url_quote_plus(x), states))
+        return ''.join(map(lambda x: 'review_state=%s&' % self.url_quote_plus(x), states))
     def getEventTypes(self):
         types = self.calendar.getCalendarTypes()
-        return ''.join(map(lambda x: 'Type=%s&amp;' % self.url_quote_plus(x), types))
+        return ''.join(map(lambda x: 'Type=%s&' % self.url_quote_plus(x), types))
     def getQueryString(self):
         request = self.request
         query_string = request.get('orig_query',
@@ -241,7 +241,7 @@ class Renderer(base.Renderer):
         if len(query_string) == 0:
             query_string = ''
         else:
-            query_string = '%s&amp;' % query_string
+            query_string = '%s&' % query_string
         return query_string
 
 


### PR DESCRIPTION
Links in the portlet calendar were with ``&amp;`` which were not always interpreted by recent browsers.

Replaced them by standards '&'.