### PR TITLE
Compatibility with latest z3c.form

### DIFF
--- a/news/161.feature
+++ b/news/161.feature
@@ -1,0 +1,2 @@
+Fixes for latest z3c.form
+[petschki]

--- a/plone/app/portlets/tests/test_formextender.py
+++ b/plone/app/portlets/tests/test_formextender.py
@@ -59,7 +59,7 @@ class PortletCssClassAdapter:
 
 class TestSchemaExtender(PortletsTestCase):
     def test_addform_fields(self):
-        schema_field_names = field.Fields(news.INewsPortlet).keys()
+        schema_field_names = [k for k in field.Fields(news.INewsPortlet).keys()]
 
         # We use the news portlet as a random example of a portlet
         portlet = getUtility(IPortletType, name="portlets.News")
@@ -67,7 +67,7 @@ class TestSchemaExtender(PortletsTestCase):
         mapping = self.portal.restrictedTraverse("++contextportlets++plone.leftcolumn")
         addview = mapping.restrictedTraverse("+/" + portlet.addview)
         addview.update()
-        addview_field_names = addview.fields.keys()
+        addview_field_names = [k for k in addview.fields.keys()]
 
         # Our addview schema before we register our extender:
         self.assertEqual(addview_field_names, schema_field_names)
@@ -85,7 +85,7 @@ class TestSchemaExtender(PortletsTestCase):
         mapping = self.portal.restrictedTraverse("++contextportlets++plone.leftcolumn")
         addview = mapping.restrictedTraverse("+/" + portlet.addview)
         addview.update()
-        addview_field_names = addview.fields.keys()
+        addview_field_names = [k for k in addview.fields.keys()]
 
         gsm.unregisterAdapter(
             PortletCssClassFormExtender,
@@ -150,14 +150,14 @@ class TestSchemaExtender(PortletsTestCase):
 
     def test_editform_fields(self):
 
-        schema_field_names = field.Fields(news.INewsPortlet).keys()
+        schema_field_names = [k for k in field.Fields(news.INewsPortlet).keys()]
 
         mapping = PortletAssignmentMapping()
         request = self.folder.REQUEST
         mapping["foo"] = news.Assignment(count=5)
         editview = getMultiAdapter((mapping["foo"], request), name="edit")
         editview.update()
-        editview_field_names = editview.fields.keys()
+        editview_field_names = [k for k in editview.fields.keys()]
 
         # Our editview schema before we register our extender:
         self.assertEqual(editview_field_names, schema_field_names)
@@ -177,7 +177,7 @@ class TestSchemaExtender(PortletsTestCase):
         mapping["foo"] = news.Assignment(count=5)
         editview = getMultiAdapter((mapping["foo"], request), name="edit")
         editview.update()
-        editview_field_names = editview.fields.keys()
+        editview_field_names = [k for k in editview.fields.keys()]
 
         gsm.unregisterAdapter(
             PortletCssClassFormExtender,


### PR DESCRIPTION
Fix tests when using `z3c.form>=4.x`