### PR TITLE
Fix error on manage-content-type-portlets view

### DIFF
--- a/news/177.bugfix
+++ b/news/177.bugfix
@@ -1,0 +1,1 @@
+Fix error on `@@manage-content-type-portlets` view. @davisagli

--- a/plone/app/portlets/browser/manage.py
+++ b/plone/app/portlets/browser/manage.py
@@ -296,12 +296,6 @@ class ManageContentTypePortlets(BrowserView):
     def portal_type(self):
         return self.fti().Title()
 
-    def portal_type_icon(self):
-        plone_layout = getMultiAdapter(
-            (self.context, self.request), name="plone_layout"
-        )
-        return plone_layout.getIcon(self.fti())
-
     @memoize
     def fti(self):
         portal_types = getToolByName(aq_inner(self.context), "portal_types")

--- a/plone/app/portlets/browser/templates/manage-content-type.pt
+++ b/plone/app/portlets/browser/templates/manage-content-type.pt
@@ -12,12 +12,6 @@
       <h1 class="documentFirstHeading"
           i18n:translate="title_manage_contenttype_portlets"
       >
-        <img tal:define="
-               icon view/portal_type_icon;
-             "
-             tal:replace="structure icon/html_tag"
-             i18n:name="contenttype_icon"
-        />
       Manage content type portlets for
         <span tal:content="view/portal_type"
               i18n:name="contenttype_name"


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/3795

plone_layout.getIcon was removed already. I'm not sure what the replacement is, but I guess it's not particularly important to show the content type icon on this page.