### PR TITLE
Disable the use of the ajax main template for manage portlet views due to some special response parsing.

### DIFF
--- a/news/+no-ajax-load.bugfix.rst
+++ b/news/+no-ajax-load.bugfix.rst
@@ -1,0 +1,1 @@
+Disable the use of the ajax main template for manage portlet views due to some special response parsing.

--- a/plone/app/portlets/browser/manage.py
+++ b/plone/app/portlets/browser/manage.py
@@ -35,6 +35,8 @@ class ManageContextualPortlets(BrowserView):
     def __init__(self, context, request):
         super().__init__(context, request)
         self.request.set("disable_border", True)
+        # Disable the ajax main template for special response handling.
+        self.request.set("ajax_load", False)
 
     # IManagePortletsView implementation
 
@@ -228,6 +230,8 @@ class ManageGroupPortlets(BrowserView):
     def __init__(self, context, request):
         super().__init__(context, request)
         self.request.set("disable_border", True)
+        # Disable the ajax main template for special response handling.
+        self.request.set("ajax_load", False)
 
     def getAssignmentMappingUrl(self, manager):
         baseUrl = str(
@@ -258,6 +262,8 @@ class ManageContentTypePortlets(BrowserView):
     def __init__(self, context, request):
         super().__init__(context, request)
         self.request.set("disable_border", True)
+        # Disable the ajax main template for special response handling.
+        self.request.set("ajax_load", False)
 
     # IManagePortletsView implementation
 


### PR DESCRIPTION
Related:
https://github.com/plone/Products.CMFPlone/pull/4188
https://github.com/plone/Products.CMFPlone/pull/4169
https://github.com/plone/plone.base/pull/85
https://github.com/plone/plonetheme.barceloneta/pull/404
https://github.com/plone/plone.app.portlets/pull/203
