### PR TITLE
Gracefully handle missing portlet renderers

### DIFF
--- a/news/1727.bugfix
+++ b/news/1727.bugfix
@@ -1,0 +1,2 @@
+Use ``queryMultiAdapter`` instead of ``getMultiAdapter`` in ``_dataToPortlet`` so a missing portlet renderer no longer crashes the page.
+@jensens

--- a/src/plone/app/portlets/manager.py
+++ b/src/plone/app/portlets/manager.py
@@ -9,6 +9,7 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from ZODB.POSException import ConflictError
 from zope.component import adapter
 from zope.component import getMultiAdapter
+from zope.component import queryMultiAdapter
 from zope.interface import Interface
 from zope.publisher.interfaces.browser import IBrowserView
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
@@ -26,7 +27,7 @@ class PortletManagerRenderer(BasePortletManagerRenderer, Explicit):
         """Helper method to get the correct IPortletRenderer for the given
         data object.
         """
-        portlet = getMultiAdapter(
+        portlet = queryMultiAdapter(
             (
                 self.context,
                 self.request,


### PR DESCRIPTION
Use `queryMultiAdapter` instead of `getMultiAdapter` in the Zope 2 `_dataToPortlet` override. Companion to plone/plone.portlets#44 which handles the base class and the `None` filtering in `_lazyLoadPortlets`.

Fixes plone/Products.CMFPlone#1727

🤖 Generated with [Claude Code](https://claude.com/claude-code)